### PR TITLE
Remove json whitespace in ingest()

### DIFF
--- a/common/ingest.py
+++ b/common/ingest.py
@@ -94,7 +94,7 @@ def ingest(data: list[Any], log_type: str):
   # [{"logText": str(log1)}, {"logText": str(log2)}, ...]
   parsed_data = list(
       map(
-          lambda i: {"logText": str(json.dumps(i).encode("utf-8"), "utf-8")},
+          lambda i: {"logText": str(json.dumps(i, separators=(',', ':')).encode("utf-8"), "utf-8")},
           data,
       )
   )


### PR DESCRIPTION
Update ingest function so that JSON objects contain no whitespace between colons and commas, to reduce body size and also make raw log searching json easier