### PR TITLE
Remove extra json.dumps

### DIFF
--- a/pubsub/main.py
+++ b/pubsub/main.py
@@ -51,11 +51,9 @@ def build_and_ingest_payload(log: Union[Dict[Any, Any], List[Any]]) -> str:
   if PAYLOAD_SIZE == 0:
     # Build a new object.
     PAYLOAD = []
-    log = json.dumps(log)
     PAYLOAD.append(log)
     PAYLOAD_SIZE = PAYLOAD_SIZE + (sys.getsizeof(json.dumps(PAYLOAD)))
   else:
-    log = json.dumps(log)
     logsize = sys.getsizeof(log)
     # Send when the payload hits a certain size.
     if PAYLOAD_SIZE + logsize > PAYLOAD_THRESHOLD:


### PR DESCRIPTION
The ingest function for pubsub messages contains an unnecessary json.dump which results in strings of JSON being ingested by Chronicle rather than JSON logs which can be parsed.

The log is also "json.dump"ed here: https://github.com/chronicle/ingestion-scripts/blob/main/common/ingest.py#L97

The double-dump ends up becoming an escaped JSON string in Chronicle rathre than a parsed log.