### PR TITLE
fix(README.md): bump python runtime version to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Execute the following command from inside the previously created directory to
 deploy the cloud function.
 
 ```
-gcloud functions deploy <FUNCTION NAME> --entry-point main --trigger-http --runtime python39 --env-vars-file .env.yml
+gcloud functions deploy <FUNCTION NAME> --entry-point main --trigger-http --runtime python310 --env-vars-file .env.yml
 ```
 
 ## Support


### PR DESCRIPTION
Addresses error below, due to type-hinting syntax only available in Python >=3.10

```
def get_reference_list(list_name: str) -> List[str] | None:
TypeError: unsupported operand type(s) for |: '_GenericAlias' and 'NoneType'. [...]
```